### PR TITLE
WIP - syntax highlighter

### DIFF
--- a/highlight.js
+++ b/highlight.js
@@ -1,0 +1,41 @@
+const Parser = require('tree-sitter');
+const Clojure = require('./index.js');
+
+const parser = new Parser();
+parser.setLanguage(Clojure);
+
+const sourceCode = `
+(defn foo
+  "hello, this is a docstring"
+  [a b]
+  (let [sum (+ a b)
+        prod (* a b)]
+     {:sum sum
+      :prod prod}))
+`;
+const tree = parser.parse(sourceCode);
+
+// create a flat list of open and close tags
+const tags = [];
+function walk(node) {
+  const { type, startIndex, endIndex, children } = node;
+  tags.push(
+    {type, i: startIndex, isOpen: true},
+    {type, i: endIndex, isOpen: false}
+  );
+  children.forEach(walk);
+}
+walk(tree.rootNode);
+tags.sort((a,b) => a.i - b.i);
+
+// output html
+let prevI = 0;
+let html = "";
+for (const { type, i, isOpen } of tags) {
+  const prevText = sourceCode.slice(prevI, i);
+  const tag = isOpen ? `<span class="${type}">` : "</span>";
+  html += prevText + tag;
+  prevI = i;
+}
+html = `<pre>${html}</pre>`;
+console.log(html);


### PR DESCRIPTION
When I run the following:

```
node highlight.js > out.html
```

And I add the following css rule in inspector:

```
span.symbol {
  color: red;
}
```

It doesn't quite look right yet, so my tag inserter is off by some:

<img width="257" alt="screen shot 2018-11-29 at 8 39 39 am" src="https://user-images.githubusercontent.com/116838/49225560-6213e780-f3b2-11e8-964e-1ce3012a1527.png">